### PR TITLE
Serial cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,9 +28,7 @@ POLL_INTERVAL=2.0
 SERIAL_PORT=/dev/ttyUSB0
 
 # Serial Connection Health Monitoring (if CONNECTION_METHOD=serial)
-CONNECTION_TIMEOUT=300
-MAX_RECONNECT_ATTEMPTS=5
-RECONNECT_DELAY=30
+SERIAL_TIMEOUT=240
 
 # Multiple Radios (JSON format, optional)
 # RADIOS=[{"name": "radio1", "host": "192.168.1.100", "port": "80", "display_name": "Home Base"}, {"name": "radio2", "host": "192.168.1.101", "port": "80", "display_name": "Mobile Unit"}]

--- a/README.md
+++ b/README.md
@@ -358,8 +358,8 @@ DEBUG_MODE=true
 - Receives packets in real-time as they arrive
 - Requires physical USB connection to the device
 - Single radio per instance
-- **Built-in resilience**: Automatic error recovery and connection health monitoring
-- All messages received by radio are queued up and passed along in sequence without fail
+- Automatic connection recovery. Will reset serial connection if 240 seconds passes with no connection. (Can be changed by setting the `SERIAL_TIMEOUT` variable)
+- All messages received by radio are queued up and passed along in sequence withotu loss, like HTTP
 
 **HTTP Connection Notes:**
 - Polls the device's web API for new messages
@@ -367,7 +367,7 @@ DEBUG_MODE=true
 - Can monitor multiple radios from one instance
 - Works over network/WiFi connections
 
-*\*Serial reliability note: While the underlying serial connection can experience occasional data corruption and protocol errors (common with USB/serial communications), Meshcord includes robust error handling that automatically recovers from these issues. You may see occasional parsing errors in the logs, but these are safely handled and do not affect message forwarding.*
+*\*Serial reliability note: While the underlying serial connection can experience occasional data corruption and protocol errors (common with USB/serial communications), Meshcord includes robust error handling that automatically recovers from these issues. You may see occasional parsing errors in the logs, but these are safely handled and do not affect message forwarding. Meshtastic logging is "chatty" and these errors can mostly be ignored.*
 
 If you must use HTTP, optimize with:
 ```bash

--- a/tests/test_meshcord.py
+++ b/tests/test_meshcord.py
@@ -411,7 +411,7 @@ class TestSerialConnectionFeatures(unittest.TestCase):
             
             self.assertEqual(bot.connection_method, 'serial')
             self.assertEqual(bot.serial_port, '/dev/ttyUSB0')
-            self.assertEqual(bot.serial_timeout, 300)  # Changed from connection_timeout
+            self.assertEqual(bot.serial_timeout, 240)  # Updated to new default (4 minutes)
 
     def test_serial_config_defaults(self):
         """Test serial configuration defaults"""
@@ -471,7 +471,7 @@ class TestSerialConnectionFeaturesAsync(unittest.IsolatedAsyncioTestCase):
             
             # Verify serial configuration
             self.assertEqual(bot.connection_method, 'serial')
-            self.assertEqual(bot.serial_timeout, 300)  # Default timeout
+            self.assertEqual(bot.serial_timeout, 240)  # Updated to new default (4 minutes)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- stripped down serial healthcheck code to remove troubleshooting redundancy and excess redundancy
- left single value of SERIAL_TIMEOUT, and changed its default from 300 to 240 seconds
- updated test code to account for changes
